### PR TITLE
fix visits link url

### DIFF
--- a/app/views/redis_analytics/application/_header.html.erb
+++ b/app/views/redis_analytics/application/_header.html.erb
@@ -5,7 +5,7 @@
     <ul class="nav nav-pills pull-right">
       <li>
         <div class="btn-group" data-toggle="buttons-radio">
-          <a href="visits" class="btn btn-small <%=' active' if request.path.end_with?('/visits') %>">Visits</a>
+          <a href="<%= visits_path %>" class="btn btn-small <%=' active' if request.path.end_with?('/visits') %>">Visits</a>
         </div>
         <div class="btn-group" data-toggle="buttons-radio" id="timeRange">
         <% RedisAnalytics.time_range_formats.map{|x| x[0]}.each do |range| %>


### PR DESCRIPTION
link currently goes to the wrong place if not mounted at `/`.

    mount RedisAnalytics::Dashboard::Engine, at: "/stats"

so you go to `/stats`, click on visits and it does to `/visits`.
this patch makes it use the proper url helper.
